### PR TITLE
Added support for listitembutton flyouts

### DIFF
--- a/WinRTXamlToolkit.UWP/Controls/ListItemButton/ListItemButton.cs
+++ b/WinRTXamlToolkit.UWP/Controls/ListItemButton/ListItemButton.cs
@@ -135,6 +135,12 @@ namespace WinRTXamlToolkit.Controls
         protected override void OnTapped(Windows.UI.Xaml.Input.TappedRoutedEventArgs e)
         {
             base.OnTapped(e);
+            
+            if (FlyoutBase.GetAttachedFlyout(this) != null)
+            {
+                FlyoutBase.ShowAttachedFlyout(this);
+                return;
+            }
 
             if (Click != null)
                 Click(this, new RoutedEventArgs());


### PR DESCRIPTION
Added support for listitembutton flyouts like regular buttons have.

Simply attach a flyout using the FlyoutBase.AttachedFlyout property and it will be shown when the button is clicked.